### PR TITLE
Increase GSC function "va" max params to GSC_MAX_PARAMS(512).

### DIFF
--- a/src/component/io.cpp
+++ b/src/component/io.cpp
@@ -137,7 +137,7 @@ namespace io
             printf("%s\n", fmt.data());
         });
 
-        function::add("va", 1, 2, []()
+        function::add("va", 1, 6, []()
         {
             auto fmt = game::get<std::string>(0);
             const auto num = game::Scr_GetNumParam(game::SCRIPTINSTANCE_SERVER);


### PR DESCRIPTION
I needed to use more parameters in my va usages so I increased the max parameters allowed by 4 since 2 felt too low.