### PR TITLE
Better check for valid entity

### DIFF
--- a/src/component/chat.cpp
+++ b/src/component/chat.cpp
@@ -128,9 +128,14 @@ namespace chat
 				const auto ent = entity.get_entity_reference();
 				const auto name = args[0].as<std::string>();
 
-				if (ent.classnum != 0 || ent.entnum > 17)
+				if (ent.classnum != 0)
 				{
 					throw std::runtime_error("Invalid entity");
+				}
+
+				if (game::g_entities[ent.entnum].client == nullptr)
+				{
+					throw std::runtime_error("Not a player entity");
 				}
 
 				userinfo_overrides[ent.entnum]["name"] = name;
@@ -144,9 +149,14 @@ namespace chat
 				const auto ent = entity.get_entity_reference();
 				const auto name = args[0].as<std::string>();
 
-				if (ent.classnum != 0 || ent.entnum > 17)
+				if (ent.classnum != 0)
 				{
 					throw std::runtime_error("Invalid entity");
+				}
+
+				if (game::g_entities[ent.entnum].client == nullptr)
+				{
+					throw std::runtime_error("Not a player entity");
 				}
 
 				userinfo_overrides[ent.entnum]["name"] = name;
@@ -158,9 +168,14 @@ namespace chat
 			gsc::method::add("resetname", [](const scripting::entity& entity, const gsc::function_args&) -> scripting::script_value
 			{
 				const auto ent = entity.get_entity_reference();
-				if (ent.classnum != 0 || ent.entnum > 17)
+				if (ent.classnum != 0)
 				{
 					throw std::runtime_error("Invalid entity");
+				}
+
+				if (game::g_entities[ent.entnum].client == nullptr)
+				{
+					throw std::runtime_error("Not a player entity");
 				}
 
 				userinfo_overrides[ent.entnum].erase("name");
@@ -173,9 +188,14 @@ namespace chat
 			{
 				const auto ent = entity.get_entity_reference();
 
-				if (ent.classnum != 0 || ent.entnum > 17)
+				if (ent.classnum != 0)
 				{
 					throw std::runtime_error("Invalid entity");
+				}
+
+				if (game::g_entities[ent.entnum].client == nullptr)
+				{
+					throw std::runtime_error("Not a player entity");
 				}
 
 				userinfo_overrides[ent.entnum].erase("clantag");
@@ -191,9 +211,14 @@ namespace chat
 				const auto ent = entity.get_entity_reference();
 				const auto name = args[0].as<std::string>();
 
-				if (ent.classnum != 0 || ent.entnum > 17)
+				if (ent.classnum != 0)
 				{
 					throw std::runtime_error("Invalid entity");
+				}
+
+				if (game::g_entities[ent.entnum].client == nullptr)
+				{
+					throw std::runtime_error("Not a player entity");
 				}
 
 				userinfo_overrides[ent.entnum]["clantag"] = name;

--- a/src/component/command.cpp
+++ b/src/component/command.cpp
@@ -120,7 +120,7 @@ namespace command
 					return;
 				}
 
-				if (!(*game::levelEntityId))
+				if (!*game::levelEntityId)
 				{
 					printf("Level not loaded\n");
 					return;
@@ -146,7 +146,7 @@ namespace command
 					return;
 				}
 
-				if (!(*game::levelEntityId))
+				if (!*game::levelEntityId)
 				{
 					printf("Level not loaded\n");
 					return;
@@ -156,6 +156,11 @@ namespace command
 				const auto sv_maxclients = game::Dvar_FindVar("sv_maxclients")->current.integer;
 
 				if (client < 0 || client >= sv_maxclients)
+				{
+					return;
+				}
+
+				if (game::g_entities[client].client == nullptr)
 				{
 					return;
 				}

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -76,6 +76,19 @@ namespace game
 		return game::Scr_GetString(SCRIPTINSTANCE_SERVER, index);
 	}
 
+	gentity_s* GetEntity(scr_entref_t entref)
+	{
+		if (entref.classnum != 0)
+		{
+			game::Scr_ObjectError("Not an entity");
+			return nullptr;
+		}
+
+		assert(entref.entnum < (1 << 10));
+
+		return &game::g_entities[entref.entnum];
+	}
+
 	scr_entref_t Scr_GetEntityIdRef(unsigned int entId)
 	{
 		scr_entref_t entref;

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -74,6 +74,7 @@ namespace game
 		return reinterpret_cast<T>(value);
 	}
 
+	gentity_s* GetEntity(scr_entref_t entref);
 	scr_entref_t Scr_GetEntityIdRef(unsigned int entId);
 	void Scr_TerminateWaitThread(scriptInstance_t inst, unsigned int localId, unsigned int startLocalId);
 	void Scr_TerminateWaittillThread(scriptInstance_t inst, unsigned int localId, unsigned int startLocalId);

--- a/src/game/symbols.hpp
+++ b/src/game/symbols.hpp
@@ -75,6 +75,10 @@ namespace game
 	WEAK symbol<unsigned int(scriptInstance_t inst, unsigned int localId)> GetStartLocalId{0x402760, 0x5D6CD0};
 	WEAK symbol<unsigned int(scriptInstance_t inst, unsigned int localId)> Scr_TerminateRunningThread{0x8F45A0, 0x8F3300};
 	WEAK symbol<void(scriptInstance_t inst, const char* error, bool force_terminal)> Scr_Error{0x403AE0, 0x5E81C0};
+	WEAK symbol<void(scriptInstance_t inst, unsigned int paramIndex, const char* error)> Scr_ParamError{0x415A30, 0x617CA0};
+	WEAK symbol<void(scriptInstance_t inst, const char* error)> Scr_ObjectError{0x561660, 0x6B67E0};
+
+	WEAK symbol<gentity_s*(scr_entref_t entref)> GetPlayerEntity{0x48B760, 0x4BF6F0};
 
 	WEAK symbol<unsigned int(scriptInstance_t inst, unsigned int localId, const char* pos, unsigned int paramcount)> VM_Execute{0x8F9550, 0x8F82B0};
 


### PR DESCRIPTION
This should be how the game checks if we are dealing with a valid entity.
checking if entnum is lower than 17 is not reliable because client could still be connecting therefore client pointer would still be null.
(I hope that made sense)