### PR TITLE
Update README + Remove clone funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,3 +586,5 @@ Custom bot names and clantags can be set by creating a file in `Plutonium/storag
 
 As shown by this example the pairs of name and clantag must be stored in an object called `names`.  
 When a bot connects it will assign the pair of name and clantag based on the order they are in the object starting from the top.
+
+* `dropAllBots()`: Kick all test clients from the lobby.

--- a/src/component/bots.cpp
+++ b/src/component/bots.cpp
@@ -62,8 +62,8 @@ namespace bots
 			return sv_bot_name_random_hook.invoke<const char*>();
 		}
 
-		int build_connect_string(char* buf, const char* connectString, const char* name, const char* xuid,
-			const char* xnaddr, int protocol, int netfield, int sessionMode, int port)
+		int build_connect_string(char* buf, const char* connect_string, const char* name, const char* xuid,
+			const char* xnaddr, int protocol, int netfield, int session_mode, int port)
 		{
 			// Default
 			auto clantag = "3arc"s;
@@ -76,8 +76,8 @@ namespace bots
 				}
 			}
 
-			return _snprintf_s(buf, 0x400, _TRUNCATE, connectString, name,
-				clantag.data(), xuid, xnaddr, protocol, netfield, sessionMode, port);
+			return _snprintf_s(buf, 0x400, _TRUNCATE, connect_string, name,
+				clantag.data(), xuid, xnaddr, protocol, netfield, session_mode, port);
 		}
 	}
 

--- a/src/component/chat.cpp
+++ b/src/component/chat.cpp
@@ -246,13 +246,6 @@ namespace chat
 				return {};
 			});
 
-			gsc::function::add("cmdexecute", [](const gsc::function_args& args) -> scripting::script_value
-			{
-				const auto cmd = args[0].as<std::string>();
-				game::Cbuf_InsertText(0, cmd.data());
-				return {};
-			});
-
 			gsc::function::add("sendservercommand", [](const gsc::function_args& args) -> scripting::script_value
 			{
 				const auto client = args[0].as<int>();

--- a/src/component/command.cpp
+++ b/src/component/command.cpp
@@ -105,6 +105,20 @@ namespace command
 		script_commands.clear();
 	}
 
+	void execute(std::string command, const bool sync)
+	{
+		command += "\n";
+
+		if (sync)
+		{
+			game::Cmd_ExecuteSingleCommand(0, 0, command.data());
+		}
+		else
+		{
+			game::Cbuf_AddText(0, command.data());
+		}
+	}
+
 	class component final : public component_interface
 	{
 	public:
@@ -175,6 +189,13 @@ namespace command
 
 				const auto name = game::SL_GetString(params[2], 0);
 				game::Scr_NotifyNum(client, 0, name, argc - 3);
+			});
+
+			gsc::function::add("executecommand", [](const gsc::function_args&) -> scripting::script_value
+			{
+				const auto cmd = game::get<std::string>(0);
+				execute(cmd);
+				return {};
 			});
 
 			gsc::function::add("addcommand", [](const gsc::function_args& args) -> scripting::script_value

--- a/src/component/command.cpp
+++ b/src/component/command.cpp
@@ -177,13 +177,6 @@ namespace command
 				game::Scr_NotifyNum(client, 0, name, argc - 3);
 			});
 
-			gsc::function::add("executecommand", [](const gsc::function_args&) -> scripting::script_value
-			{
-				const auto cmd = game::get<const char*>(0);
-				game::Cbuf_InsertText(0, cmd);
-				return {};
-			});
-
 			gsc::function::add("addcommand", [](const gsc::function_args& args) -> scripting::script_value
 			{
 				const auto name = args[0].as<std::string>();

--- a/src/component/command.hpp
+++ b/src/component/command.hpp
@@ -25,4 +25,6 @@ namespace command
 
 	void add_script_command(const std::string& name, const std::function<void(const params&)>& callback);
 	void clear_script_commands();
+
+	void execute(std::string command, const bool sync = false);
 }

--- a/src/game/symbols.hpp
+++ b/src/game/symbols.hpp
@@ -10,6 +10,7 @@ namespace game
 
 	WEAK symbol<void(int localClientNum, const char* text)> Cbuf_InsertText{0x4A5FF0, 0x702E40};
 	WEAK symbol<void(int localClientNum, const char* text)> Cbuf_AddText{0x5C6F10, 0x6B9D20};
+	WEAK symbol<void(int localClientNum, int controllerIndex, const char* text)> Cmd_ExecuteSingleCommand{0x6B9C10, 0x43B8D0};
 	WEAK symbol<void(const char* cmdName, void(), cmd_function_t* allocedCmd)> Cmd_AddCommandInternal{0x5B3070, 0x4DC2A0};
 	WEAK symbol<const char*(int index)> Cmd_Argv{0x5608F0, 0x6B3D40};
 	WEAK symbol<void(const char* cmdName)> Cmd_RemoveCommand{0x6033D0, 0x65EB30};


### PR DESCRIPTION
Added info to newly added gsc func to the readme
pluto supports execcmd natively so I don't see why these two functions should exists x)