### PR TITLE
add getfunctionargcount + cleanup

### DIFF
--- a/src/component/gsc.cpp
+++ b/src/component/gsc.cpp
@@ -415,6 +415,18 @@ namespace gsc
                 const auto function = args[0].as<scripting::function>();
                 return function.get_name();
             });
+            
+            function::add("getfunctionargcount", [](const function_args& args)
+            {
+                const auto function = args[0].as<scripting::function>();
+                const auto pos = function.get_pos();
+                if (*pos != 0x17) // OP_SafeCreateLocalVariables
+                {
+                    return 0;
+                }
+
+                return static_cast<int>(pos[1]);
+            });
 
             function::add("arrayremovekey", [](const function_args& args) -> scripting::script_value
             {

--- a/src/component/io.cpp
+++ b/src/component/io.cpp
@@ -73,20 +73,6 @@ namespace io
 				return fmt;
 			});
 
-			gsc::function::add("print", [](const gsc::function_args& args) -> scripting::script_value
-			{
-				const auto args_ = args.get_raw();
-
-				for (const auto arg : args_)
-				{
-					printf("%s\t", arg.to_string().data());
-				}
-
-				printf("\n");
-
-				return {};
-			});
-
 			gsc::function::add("jsonprint", [](const gsc::function_args& args) -> scripting::script_value
 			{
 				std::string buffer;

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1,19 +1,12 @@
 #include <stdinc.hpp>
 #include "loader/component_loader.hpp"
 
-#include "game/game.hpp"
-
 #include <utils/hook.hpp>
 
 BOOL APIENTRY DllMain(HMODULE /*module_*/, DWORD ul_reason_for_call, LPVOID /*reserved_*/)
 {
 	if (ul_reason_for_call == DLL_PROCESS_ATTACH)
 	{
-		if (game::plutonium::is_up_to_date())
-		{
-			utils::hook::jump(reinterpret_cast<uintptr_t>(&printf), game::plutonium::printf);
-		}
-
 		component_loader::post_unpack();
 	}
 

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -78,11 +78,6 @@ namespace game
 	scr_entref_t Scr_GetEntityIdRef(unsigned int entId);
 	void Scr_TerminateWaitThread(scriptInstance_t inst, unsigned int localId, unsigned int startLocalId);
 	void Scr_TerminateWaittillThread(scriptInstance_t inst, unsigned int localId, unsigned int startLocalId);
-
-	namespace plutonium
-	{
-		bool is_up_to_date();
-	}
 }
 
 #include "symbols.hpp"

--- a/src/game/symbols.hpp
+++ b/src/game/symbols.hpp
@@ -127,9 +127,4 @@ namespace game
 	WEAK symbol<unsigned int> levelEntityId{0x2E1A51C, 0x2DEA81C};
 
 	WEAK symbol<client_s> svs_clients{0x291C0C0, 0x28EC9C0};
-
-	namespace plutonium
-	{
-		WEAK symbol<int(const char* fmt, ...)> printf{0x209F30F0, 0x209F30F0};
-	}
 }


### PR DESCRIPTION
additional notes
- plutonium no longer uses curses for console and normal printf will go to console now
- the `print` function added here exists in Plutonium alongside their `printf` function