### PR TITLE
Fix child variable counting.

### DIFF
--- a/src/component/debug.cpp
+++ b/src/component/debug.cpp
@@ -251,7 +251,7 @@ namespace debug
         int* alloc_child_variable_stub(int inst, unsigned int* index)
         {
             const auto result = alloc_child_variable_hook.invoke<int*>(inst, index);
-            const auto pos = game::scr_VmPub->function_frame->fs.pos;
+            const auto pos = game::fs->pos;
             allocations[*index] = pos;
             return result;
         }


### PR DESCRIPTION
Guy(Pluto dev) found a mistake related to the counting of child script variables in t6-gsc-utils while trying to port the functionality to T4.

This commit fixes the mistake.