### PR TITLE
Only count script variables if spawned by script.

### DIFF
--- a/src/component/debug.cpp
+++ b/src/component/debug.cpp
@@ -251,8 +251,11 @@ namespace debug
         int* alloc_child_variable_stub(int inst, unsigned int* index)
         {
             const auto result = alloc_child_variable_hook.invoke<int*>(inst, index);
-            const auto pos = game::fs->pos;
-            allocations[*index] = pos;
+            if (game::scr_VmPub[inst].function_count)
+            {
+                const auto pos = game::fs->pos;
+                allocations[*index] = pos;
+            }
             return result;
         }
 


### PR DESCRIPTION
I forgot to add this to the previous pr but @ineedbots recommends it so the counts don't add variables allocated by the engine to random functions.